### PR TITLE
Add LAUNCH_JBOSS_IN_BACKGROUND to support graceful shutdown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ RUN cd $HOME && curl http://download.jboss.org/wildfly/$WILDFLY_VERSION/wildfly-
 # Set the JBOSS_HOME env variable
 ENV JBOSS_HOME /opt/jboss/wildfly
 
+# Ensure signals are forwarded to the JVM process correctly for graceful shutdown
+ENV LAUNCH_JBOSS_IN_BACKGROUND true
+
 # Expose the ports we're interested in
 EXPOSE 8080
 


### PR DESCRIPTION
At the moment the WildFly image needs a TTY in order to be shut down gracefully. 

For example start a WildFly container with:
```
docker run jboss/wildfly
```
Then follow this up with `CTRL+C` - nothing happens. Try `docker stop <container id>` and the command times out, resulting in the container being forcibly killed.

Presumably this happens because `SIGINT` / `SIGTERM`  is being sent to the standalone.sh wrapper script and not the app server Java process. 

This PR ensures that the app server can be shut down gracefully from `CTRL+C` and `docker stop` events.