### PR TITLE
Fix Bug #76 Add support to set the password for Root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ RUN cd $HOME \
 # Ensure signals are forwarded to the JVM process correctly for graceful shutdown
 ENV LAUNCH_JBOSS_IN_BACKGROUND true
 
+# Ensure the user could set the password for root user
+RUN passwd --delete root
+
 USER jboss
 
 # Expose the ports we're interested in


### PR DESCRIPTION
Currently the root user is at the Wildfly container
is unable to set up the password.

Deleting the previous root password from the docker image creation
after ran all stuff.

With this change, the root user could be user without require password
through ` su ` command and the change the password.

Signed-off-by: Felipe de Jesus Ruiz Garcia <me@tranzemc.com>