### PR TITLE
Add DockerHub release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,31 @@
+name: publish-release
+on:
+  push:
+    tags:
+      - "*.Final"
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: jboss/wildfly
+          tags: type=ref,event=tag
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -5,6 +5,7 @@ on:
       - "*.Final"
 jobs:
   docker:
+    environment: dockerhub
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
@@ -20,8 +21,8 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.USERNAME }}
+          password: ${{ secrets.TOKEN }}
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2


### PR DESCRIPTION
As stated in https://github.com/jboss-dockerfiles/wildfly/issues/145 adds GitHub Actions workflow to build and publish tags to DockerHub repo.

Please create a CLI/token login for DockerHub and two corresponding GitHub secrets in advance:
- **DOCKERHUB_USERNAME**
- **DOCKERHUB_TOKEN**