### PR TITLE
Add GitHub action to publish to quay.io

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,34 @@
+name: publish-release
+
+on:
+  push:
+    tags:
+      - "*.Final"
+jobs:
+  image:
+    environment: quay.io
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ secrets.REGISTRY }}/${{ secrets.IMAGE }}
+          tags: type=ref,event=tag
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Docker Login to Quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.REGISTRY }}
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }},latest


### PR DESCRIPTION
When a tag is pushed to this GitHub repository,
this action will build an image and push it to quay.io with the git tag
as well as the `latest` tag.

This action is using the `quay.io` environment
with the following secrets:

* `REGISTRY` set to `quay.io`
* `IMAGE` set to `wildfly/wildfly`
* `REGISTRY_USER` set to `wildfly+github_actions`
* `REGISTRY_PASSWORD` set to the credential of the Robot account
   wildfly+github_action on quay.io

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>