### PR TITLE
Add Dockerfile for JDK 20 on Red Hat UBI 9

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -13,12 +13,18 @@ on:
 
 jobs:
   image:
-    strategy:
-      matrix:
-        jdk-version: [11, 17, 19]
     env:
       # Put the "latest" tag on this JDK version
       JDK_VERSION_FOR_LATEST: 17
+    strategy:
+      matrix:
+        include:
+          - jdk-version: 11
+            dist: centos7
+          - jdk-version: 17
+            dist: centos7
+          - jdk-version: 20
+            dist: ubi9-minimal
     environment: quay.io
     runs-on: ubuntu-latest
     steps:
@@ -53,6 +59,8 @@ jobs:
         with:
           push: true
           platforms: linux/amd64,linux/arm64
-          build-args: jdk=${{ matrix.jdk-version }}
+          build-args: |
+            jdk=${{ matrix.jdk-version }}
+            dist=${{ matrix.dist }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
-# By default, build on JDK 17
+# By default, build on JDK 17 on CentOS 7.
 ARG jdk=17
-FROM eclipse-temurin:${jdk}-centos7
+# Red Hat UBI 9 (ubi9-minimal) should be used on JDK 20 and later.
+ARG dist=centos7
+FROM eclipse-temurin:${jdk}-${dist}
 
 LABEL org.opencontainers.image.source=https://github.com/jboss-dockerfiles/wildfly org.opencontainers.image.title=wildfly org.opencontainers.imag.url=https://github.com/jboss-dockerfiles/wildfly org.opencontainers.image.vendor=WildFly
 

--- a/README.md
+++ b/README.md
@@ -15,15 +15,17 @@ Previous repository at [https://hub.docker.com/r/jboss/wildfly](https://hub.dock
 WildFly publishes images to run the application server with different JDK versions.
 The tag of the image identifies the version of WildFly as well as the JDK version in the images.
 
-For each release of WildFly (e.g. `27.0.0.Final`), there are fixed tags for each supported JDK version:
+For each release of WildFly (e.g. `28.0.0.Final`), there are fixed tags for each supported JDK version:
 
-* `quay.io/wildfly/wildfly:27.0.0.Final-jdk11`
-* `quay.io/wildfly/wildfly:27.0.0.Final-jdk17`
+* `quay.io/wildfly/wildfly:28.0.0.Final-jdk11`
+* `quay.io/wildfly/wildfly:28.0.0.Final-jdk17`
+* `quay.io/wildfly/wildfly:28.0.0.Final-jdk20`
 
 There are also floating tags available to pull the _latest release of WildFly on the various JDK_:
 
 * `quay.io/wildfly/wildfly:latest-jdk11`
 * `quay.io/wildfly/wildfly:latest-jdk17`
+* `quay.io/wildfly/wildfly:latest-jdk20`
 
 Finally, there is the `latest` tag that pull the _latest release of WildFly on the latest LTS JDK version_:
 
@@ -104,9 +106,13 @@ Then you can build the image:
 
     docker build --tag=jboss/wildfly-admin .
 
-Or for jdk 11:
+Or for JDK 11:
 
-    docker build --build-arg jdk=11 --tag=jboss/wildfly-admin .
+    docker build --build-arg dist=centos7 --build-arg jdk=11 --tag=jboss/wildfly-admin .
+
+Or for JDK 20:
+
+    docker build --build-arg dist=ubi9-minimal --build-arg jdk=20 --tag=jboss/wildfly-admin .
 
 Run it:
 
@@ -120,9 +126,11 @@ You don't need to do this on your own, because we prepared a trusted build for t
 
     docker build --rm=true --tag=jboss/wildfly .
 
-## Image internals [updated Novembber,10 2022]
+## Image internals [updated May 4, 2023]
 
-This image extends [`eclipse-temurin`](https://hub.docker.com/_/eclipse-temurin/tags) jdk (17 by default) centos7 image, installs the wildfly server and sets up the jboss environment similar to [`jboss/base`](https://github.com/jboss-dockerfiles/base) image. Please refer to the README.md for selected images for more info.
+This image extends the [`eclipse-temurin`](https://hub.docker.com/_/eclipse-temurin) JDK. Starting with JDK 20, this base OS used is [`ubi9-minimal`](https://catalog.redhat.com/software/containers/ubi9-minimal/61832888c0d15aff4912fe0d). Earlier versions, including the LTS JDK 11 and JDK 17, are based on [`centos7`](https://hub.docker.com/_/centos). A UBI 9 image to validate the build arguments provided.
+
+This image installs the wildfly server and sets up the JBoss environment similar to [`jboss/base`](https://github.com/jboss-dockerfiles/base) image. Please refer to the README.md for selected images and more info.
 
 The server is run as the `jboss` user which has the uid/gid set to `1000`.
 


### PR DESCRIPTION
- Splitting the current Dockerfile into two: <= JDK 19 (on CentOS 7) and >= JDK 20 (on Red Hat UBI 9) 
  - Dockerfiles don't really support swappable base images ([buildah](https://github.com/containers/buildah) would work better for that), so the solution here is a multi-stage build, with the first stage validating that the JDK matches the file bounds. The stage isn't necessary, but makes for a decent sanity check.
- Updated the CI action by splitting it into CentOS and UBI jobs. Same as above, there isn't an easy way to filter a matrix of JDK versions without switching off Dockerfiles entirely.

Closes #175.