### PR TITLE
Request to build and release images for s390x

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -20,11 +20,14 @@ jobs:
       matrix:
         include:
           - jdk-version: 11
-            dist: centos7
+            dist: ubi9-minimal
+            platforms: linux/amd64,linux/arm64,linux/s390x
           - jdk-version: 17
-            dist: centos7
+            dist: ubi9-minimal
+            platforms: linux/amd64,linux/arm64,linux/s390x
           - jdk-version: 20
             dist: ubi9-minimal
+            platforms: linux/amd64,linux/arm64
     environment: quay.io
     runs-on: ubuntu-latest
     steps:
@@ -58,7 +61,7 @@ jobs:
         uses: docker/build-push-action@v3.2.0
         with:
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platforms }}
           build-args: |
             jdk=${{ matrix.jdk-version }}
             dist=${{ matrix.dist }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -20,14 +20,14 @@ jobs:
       matrix:
         include:
           - jdk-version: 11
-            dist: ubi9-minimal
-            platforms: linux/amd64,linux/arm64,linux/s390x
-          - jdk-version: 17
-            dist: ubi9-minimal
-            platforms: linux/amd64,linux/arm64,linux/s390x
-          - jdk-version: 20
-            dist: ubi9-minimal
+            dist: centos7
             platforms: linux/amd64,linux/arm64
+          - jdk-version: 17
+            dist: centos7
+            platforms: linux/amd64,linux/arm64
+          - jdk-version: 21
+            dist: ubi9-minimal
+            platforms: linux/amd64,linux/arm64,linux/s390x
     environment: quay.io
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Changes included in this PR:
1. Updated base image to `eclipse-temurin:ubi9-minimal` considering it supports multiple archs. Also centos 7 will reach its [end of life](https://www.redhat.com/en/events/webinar/centos-linux-reaching-its-end-life-now-what#:~:text=Updates%20and%20releases%20of%20CentOS,7%20on%20June%2030%2C%202024) down the line. Wanted to understand whether this change would have any major impact on existing users?
2. Added s390x to jdk 11 & 17 matrix as jdk 20 is `not yet` available for s390x.

Resolves #173 
