### PR TITLE
CI: split into 2 jobs

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -17,11 +17,51 @@ on:
       - "main"
 
 jobs:
-  image:
+  test:
+    # Only build linux/amd64 images for testing
+    env:
+      IMAGE_TEST: wildfly-test:latest
+    strategy:
+      matrix:
+        include:
+          - jdk-version: 11
+            dist: ubi9-minimal
+            platforms: linux/amd64
+          - jdk-version: 17
+            dist: ubi9-minimal
+            platforms: linux/amd64
+          - jdk-version: 21
+            dist: ubi9-minimal
+            platforms: linux/amd64
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4.2.0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.2.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.6.1
+      - name: Build WildFly images
+        id: docker_build
+        uses: docker/build-push-action@v6.7.0
+        with:
+          load: true
+          tags: ${{ env.IMAGE_TEST }}
+          build-args: |
+            jdk=${{ matrix.jdk-version }}
+            dist=${{ matrix.dist }}
+      - name: Smoke Test
+        run: |
+          ./scripts/smoke-test.sh ${{ env.IMAGE_TEST }}
+
+  # Push to the container registry only when a new tag is pushed
+  push:
+    needs: test
+    environment: quay.io
+    if: startsWith(github.event.ref, 'refs/tags/')
     env:
       # Put the "latest" tag on this JDK version
       JDK_VERSION_FOR_LATEST: 21
-      IMAGE_TEST: wildfly-test:latest
     strategy:
       matrix:
         include:
@@ -34,7 +74,6 @@ jobs:
           - jdk-version: 21
             dist: ubi9-minimal
             platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
-    environment: quay.io
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
@@ -56,15 +95,6 @@ jobs:
         uses: docker/setup-qemu-action@v3.2.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.6.1
-      - name: Build WildFly images
-        id: docker_build
-        uses: docker/build-push-action@v6.7.0
-        with:
-          load: true
-          tags: ${{ env.IMAGE_TEST }}
-      - name: Smoke Test
-        run: |
-          ./scripts/smoke-test.sh ${{ env.IMAGE_TEST }}
       - name: Docker Login to Quay.io
         if: startsWith(github.event.ref, 'refs/tags/')
         uses: docker/login-action@v3.3.0
@@ -73,9 +103,7 @@ jobs:
           username: ${{ secrets.REGISTRY_USER }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
       - name: Push WildFly images to container registry
-        # Only push to the container registry when a new tag is pushed to the repository
         id: docker_push
-        if: startsWith(github.event.ref, 'refs/tags/')
         uses: docker/build-push-action@v6.7.0
         with:
           push: true


### PR DESCRIPTION
* `test` is always run
* `push` is only run when a tag is pushed (and use the `quay.io`  environment)