### PR TITLE
Update group setting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,33 +11,30 @@ LABEL org.opencontainers.image.source=https://github.com/jboss-dockerfiles/wildf
 # Conditional RUN: IF no groupadd AND microdnf THEN: update, install shadow-utils, clean
 RUN if ! [ -x "$(command -v groupadd)" ] && [ -x "$(command -v microdnf)" ]; then microdnf update -y && microdnf install --best --nodocs -y shadow-utils && microdnf clean all; fi
 
-WORKDIR /opt/jboss
 
-RUN groupadd -r jboss -g 1000 && useradd -u 1000 -r -g jboss -m -d /opt/jboss -s /sbin/nologin -c "JBoss user" jboss && \
+RUN useradd -r -g 0 -m -d /opt/jboss -s /sbin/nologin -c "JBoss user" jboss && \
     chmod 755 /opt/jboss
+
+WORKDIR /opt/jboss
+USER jboss
 
 # Set the WILDFLY_VERSION env variable
 ENV WILDFLY_VERSION=34.0.1.Final
 ENV WILDFLY_SHA1=eca3a94bb8a91538f7f2642f9d04d89a25f53846
 ENV JBOSS_HOME=/opt/jboss/wildfly
 
-USER root
 
 # Add the WildFly distribution to /opt, and make wildfly the owner of the extracted tar content
 # Make sure the distribution is available from a well-known place
-RUN cd $HOME \
-    && curl -L -O https://github.com/wildfly/wildfly/releases/download/$WILDFLY_VERSION/wildfly-$WILDFLY_VERSION.tar.gz \
+RUN curl -L -O https://github.com/wildfly/wildfly/releases/download/$WILDFLY_VERSION/wildfly-$WILDFLY_VERSION.tar.gz \
     && sha1sum wildfly-$WILDFLY_VERSION.tar.gz | grep $WILDFLY_SHA1 \
     && tar xf wildfly-$WILDFLY_VERSION.tar.gz \
-    && mv $HOME/wildfly-$WILDFLY_VERSION $JBOSS_HOME \
+    && mv ./wildfly-$WILDFLY_VERSION $JBOSS_HOME \
     && rm wildfly-$WILDFLY_VERSION.tar.gz \
-    && chown -R jboss:0 ${JBOSS_HOME} \
     && chmod -R g+rw ${JBOSS_HOME}
 
 # Ensure signals are forwarded to the JVM process correctly for graceful shutdown
 ENV LAUNCH_JBOSS_IN_BACKGROUND=true
-
-USER jboss
 
 # Expose the ports in which we're interested
 EXPOSE 8080


### PR DESCRIPTION
Set the jboss user's group to 0 so that when the container runs in OpenShift, its user (which would not be jboss) would still belong to the same root group.

This also simplifies the Dockerfile instructions as the installation of WildFly can be done directly by the jboss user (instead of root) and there is no need to change the whole installation ownership to jboss:0 as it will be done automatically.